### PR TITLE
Build fixes for vulcan

### DIFF
--- a/tracer/tracer-driver.C
+++ b/tracer/tracer-driver.C
@@ -1300,7 +1300,7 @@ static tw_stime exec_task(
     m->model_net_calls = 0;
     if(ns->my_pe->taskExecuted[task_id.iter][task_id.taskid]) {
       b->c10 = 1;
-      return;
+      return 0;
     }
     //Check if the backward dependencies are satisfied
     //If not, do nothing yet
@@ -1630,7 +1630,7 @@ static tw_stime exec_task(
            taskEntry->node, taskEntry->msgId.id, taskEntry->msgId.comm, 
            taskEntry->msgId.seq, t->isNonBlocking, t->req_id, b->c26, b->c27, task_id.taskid);
 #endif
-          if(!t->isNonBlocking) return;
+          if(!t->isNonBlocking) return 0;
           sendFinishTime += sendOffset+copyTime+nic_delay;
         }
       }
@@ -1661,7 +1661,7 @@ static tw_stime exec_task(
           ns->my_pe->pendingReqs[t->req_id] = task_id.taskid;
         }
         b->c29 = 1;
-        return;
+        return 0;
       } 
     }
 #endif

--- a/tracer/tracer-driver.h
+++ b/tracer/tracer-driver.h
@@ -32,20 +32,6 @@ struct proc_state
     int my_pe_num, my_job;
 };
 
-struct proc_msg
-{
-    enum proc_event proc_event_type;
-    tw_lpid src;          /* source of this request or ack */
-    int iteration;
-    TaskPair executed;
-    int fwd_dep_count;
-    int saved_task;
-    MsgID msgId;
-    bool incremented_flag; /* helper for reverse computation */
-    int model_net_calls;
-    unsigned int coll_info;
-};
-
 /* types of events that will constitute triton requests */
 enum proc_event
 {
@@ -68,6 +54,20 @@ enum proc_event
     COLL_A2A_BLOCKED_SEND_DONE,
     RECV_COLL_POST,
     COLL_COMPLETE
+};
+
+struct proc_msg
+{
+    enum proc_event proc_event_type;
+    tw_lpid src;          /* source of this request or ack */
+    int iteration;
+    TaskPair executed;
+    int fwd_dep_count;
+    int saved_task;
+    MsgID msgId;
+    bool incremented_flag; /* helper for reverse computation */
+    int model_net_calls;
+    unsigned int coll_info;
 };
 
 struct Coll_lookup {


### PR DESCRIPTION
Fixes for building TraceR on Blue Gene/Q system, as tested on Vulcan. These include the following changes:
- Added a return value inside function definitions returning double.
- Blue Gene/Q defaults to big endian format, which was resulting in an incorrect reading of some configuration files. Made some changes to convert endianness while reading.