### PR TITLE
Add check for when # of ranks in trace > # of servers in topology.

### DIFF
--- a/tracer/tracer-driver.C
+++ b/tracer/tracer-driver.C
@@ -372,6 +372,12 @@ int main(int argc, char **argv)
             i, jobs[i].numRanks, jobs[i].traceDir, jobs[i].map_file, jobs[i].numIters);
         }
     }
+    if (total_ranks > num_servers) {
+      if (!rank)
+        printf("Job requires %d servers, but the topology only contains %d. Aborting\n", total_ranks, num_servers);
+      MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
 
     if(!rank) {
       printf("Done reading meta-information about jobs\n");


### PR DESCRIPTION
Right now, when this is true, there's an out-of-bounds array access at tracer-driver.C:435, that was overwriting the trace path. TraceR still crashed, but with a totally unrelated error:
[OTF2] src/OTF2_Reader.c:1153: error: Parameter value out of range: Could not find file extension!
It took me a couple of hours to find the actual problem, so hopefully this will save someone else some time.