### PR TITLE
Add BigSim and Creating Network Config File sections to the user guide

### DIFF
--- a/docs/UserWriteUp.txt
+++ b/docs/UserWriteUp.txt
@@ -51,7 +51,7 @@ If using UDP as the BigSim/Charm++'s communication layer:
 If using MPI as the BigSim/Charm++'s communication layer:
 mpirun -n<number of real processes> ./pgm <program arguments> +vp<number of processes expected on the future system> +x<x dim> +y<y dim> +z<z dim> +bglog
 
-Number of real processes is typically equalt to the number cores the emulation
+Number of real processes is typically equal to the number cores the emulation
 is being run on.
 
 machine file is the list of systems the emulation should be run on (similar to
@@ -69,7 +69,7 @@ effect on the emulation, but exist due to historical reasons.
 
 +bglog instructs bigsim to write the logs to files.
 
-When this run finished, you should use many files named bgTrace* in the
+When this run finished, you should see many files named bgTrace* in the
 directory. The total number of such files equals the number of real processes
 plus one. Their names are bgTrace, bgTrace0, bgTrace1, so on.
 
@@ -77,7 +77,7 @@ Create a new folder and move all bgTrace to that folder.
 
 5) Following instructions in README.OTF to generate OTF2 traces.
 
-6) Simulation. To run simulation, 2 files are needed: a tracer config file,
+6) Simulation. To run a simulation, 2 files are needed: a tracer config file,
 and a codes config file. Optionally, mapping files can also be provided.
 
 Tracer config file: sample found at examples/jacobi2d-bigsim/tracer_config (BigSim) or examples/stencil4d-otf/tracer_config (OTF) Format (expected content on each line of the file):

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -19,8 +19,8 @@ Some useful options to use with TraceR:
 --max-opt-lookahead    leash on optimistic execution in nanoseconds (1 microsecond is a good value)
 --timer-frequency      frequency with which PE0 should print current virtual time
 
-Creating a TraceR config file
------------------------------
+Creating a TraceR configuration file
+------------------------------------
 
 This is the format for the TraceR config file::
 
@@ -28,11 +28,16 @@ This is the format for the TraceR config file::
     <num jobs>
     <Trace path for job0> <map file for job0> <number of ranks in job0> <iterations (use 1 if running in normal mode)>
     <Trace path for job1> <map file for job1> <number of ranks in job1> <iterations (use 1 if running in normal mode)>
+    ...
+    <Trace path for jobN> <map file for jobN> <number of ranks in jobN> <iterations (use 1 if running in normal mode)>
+
 
 If you do not intend to create global or per-job map files, you can use ``NA``
 instead of them.
 
-See below to generate global or per-job map files.
+Sample TraceR config files can be found in examples/jacobi2d-bigsim/tracer_config (BigSim) or examples/stencil4d-otf/tracer_config (OTF)
+
+See `Creating the job placement file`_ below for how to generate global or per-job map files.
 
 Creating the network (CODES) configuration file
 -----------------------------------------------
@@ -41,7 +46,7 @@ Sample network configuration files can be found in examples/conf
 Additional documentation on the format of the CODES config file can be found in the
 CODES wiki at https://xgitlab.cels.anl.gov/codes/codes/wikis/home
 
-A brief summary follows:
+A brief summary of the format follows.
 
 LPGROUPS, MODELNET_GRP, PARAMS are keywords and should be used as is.
 
@@ -51,7 +56,7 @@ MODELNET_GRP::
 
     server = number of MPI processes/cores per router
 
-    modelnet_\* = number of NICs. For torus, this value has to be 1; for dragonfly,
+    modelnet_* = number of NICs. For torus, this value has to be 1; for dragonfly,
     it should be router radix divided by 4; for the fat-tree, it should be router
     radix divided by 2. For the dragonfly network, modelnet_dragonfly_router should
     also be specified (as 1). For express mesh, modelnet_express_mesh_router should
@@ -74,8 +79,8 @@ Other common parameters::
     modelnet_order = torus/dragonfly/fattree/slimfly/express_mesh
 
     modelnet_scheduler =
-        fcfs : packetize messages one by one.
-        round-robin : packetize message in a round robin manner.
+        fcfs: packetize messages one by one.
+        round-robin: packetize message in a round robin manner.
 
     message_size = PDES parameter (keep constant at 512)
 
@@ -90,10 +95,10 @@ Other common parameters::
     buffer_size/vc_size = size of channels used to store transient packets at routers (in
     bytes). Typical value is 64*packet_size.
 
-    routing = how are packets being routed. Options depend on the network:
-        torus = static/adaptive
-        dragonfly = minimal/nonminimal/adaptive
-        fat-tree = adaptive/static
+    routing = how are packets being routed. Options depend on the network.
+        torus: static/adaptive
+        dragonfly: minimal/nonminimal/adaptive
+        fat-tree: adaptive/static
 
 Network specific parameters::
 

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -12,12 +12,11 @@ optimistic mode::
 
     mpirun -np <p> ../traceR --sync=3  -- <network_config> <tracer_config>
 
-Some useful options to TraceR.
-
+Some useful options to use with TraceR:
 --sync                 ROSS's PDES type. 1 - sequential, 2 - conservative, 3 - optimistic
 --nkp                  number of groups used for clustering LPs; recommended value for lower rollbacks: (total #LPs)/(#MPI processes)
 --extramem             number of messages in ROSS's extra message buffer (each message is ~500 bytes, 100K should work for most cases)
---max-opt-lookahead    leash on optimisitc execution in nanoseconds (1 micro second is a good value)
+--max-opt-lookahead    leash on optimistic execution in nanoseconds (1 microsecond is a good value)
 --timer-frequency      frequency with which PE0 should print current virtual time
 
 Creating a TraceR config file
@@ -35,8 +34,82 @@ instead of them.
 
 See below to generate global or per-job map files.
 
-Creating the target system configuration
-----------------------------------------
+Creating the network (CODES) configuration file
+-----------------------------------------------
+Sample network configuration files can be found in examples/conf
+
+Additional documentation on the format of the CODES config file can be found in the
+CODES wiki at https://xgitlab.cels.anl.gov/codes/codes/wikis/home
+
+A brief summary follows:
+
+LPGROUPS, MODELNET_GRP, PARAMS are keywords and should be used as is.
+
+MODELNET_GRP::
+
+    repetition = number of routers that have nodes connecting to them.
+
+    server = number of MPI processes/cores per router
+
+    modelnet_\* = number of NICs. For torus, this value has to be 1; for dragonfly,
+    it should be router radix divided by 4; for the fat-tree, it should be router
+    radix divided by 2. For the dragonfly network, modelnet_dragonfly_router should
+    also be specified (as 1). For express mesh, modelnet_express_mesh_router should
+    also be specified as 1.
+
+    Similarly, the fat-tree config file requires specifying fattree_switch which
+    can be 2 or 3, depending on the number of levels in the fat-tree. Note that the
+    total number of cores specified in the CODES config file can be greater than
+    the number of MPI processes being simulated (specified in the tracer config
+    file).
+
+Other common parameters::
+
+    packet_size/chunk_size (both should have the same value) = size of the packets
+    created by NIC for transmission on the network. Smaller the packet size, longer
+    the time for which simulation will run (in real time). Larger the packet size,
+    the less accurate the predictions are expected to be (in virtual time). Packet
+    sizes of 512 bytes to 4096 bytes are commonly used.
+
+    modelnet_order = torus/dragonfly/fattree/slimfly/express_mesh
+
+    modelnet_scheduler =
+        fcfs : packetize messages one by one.
+        round-robin : packetize message in a round robin manner.
+
+    message_size = PDES parameter (keep constant at 512)
+
+    router_delay = delay at each router for packet transmission (in nanoseconds)
+
+    soft_delay = delay caused by software stack such as that of MPI (in nanoseconds)
+
+    link_bandwidth = bandwidth of each link in the system (in GB/s)
+
+    cn_bandwidth = bandwidth of connection between NIC and router (in GB/s)
+
+    buffer_size/vc_size = size of channels used to store transient packets at routers (in
+    bytes). Typical value is 64*packet_size.
+
+    routing = how are packets being routed. Options depend on the network:
+        torus = static/adaptive
+        dragonfly = minimal/nonminimal/adaptive
+        fat-tree = adaptive/static
+
+Network specific parameters::
+
+    Torus:
+        n_dims = number of dimensions in the torus
+        dim_length = length of each dimension
+
+    Dragonfly:
+        num_routers = number of routers within a group.
+        global_bandwidth = bandwidth of the links that connect groups.
+
+    Fat-tree:
+        ft_type = always choose 1
+        num_levels = number of levels in the fat-tree (2 or 3)
+        switch_radix =  radix of the switch being used
+        switch_count = number of switches at leaf level.
 
 Creating the job placement file
 -------------------------------

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -128,12 +128,13 @@ for more detail). Use any one of the following commands:
 
     ./build bgampi mpi-linux-x86_64 bigemulator --with-production --enable-tracing
 
-Note that this build is used to compile MPI applications so that traces can be
-generated. Hence, the communication layer used by BigSim/Charm++ is not
-important. During simulation, the communication will be replayed using the
-network simulator from CODES. However, the computation time captured here can be
-important if it is not being explicitly replaced at simulation time using
-configuration options. So using appropriate compiler flags is important.
+.. note::
+   This build is used to compile MPI applications so that traces can be
+   generated. Hence, the communication layer used by BigSim/Charm++ is not
+   important. During simulation, the communication will be replayed using the
+   network simulator from CODES. However, the computation time captured here can be
+   important if it is not being explicitly replaced at simulation time using
+   configuration options. So using appropriate compiler flags is important.
 
 Quick start
 """""""""""

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -143,9 +143,6 @@ Generating OTF2 traces with an MPI program using Score-P
 
 Detailed instructions are available at https://silc.zih.tu-dresden.de/scorep-current/pdf/scorep.pdf.
 
-Quick start
-"""""""""""
-
 1. Add $SCOREP_INSTALL/bin to your PATH for convenience. Example::
 
     export SCOREP_INSTALL=$HOME/workspace/scoreP/scorep-3.0/install
@@ -217,8 +214,8 @@ for more detail). Use any one of the following commands:
    important if it is not being explicitly replaced at simulation time using
    configuration options. So using appropriate compiler flags is important.
 
-Quick start
-"""""""""""
+Generating AMPI traces with an MPI program using BigSim
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 1. Compile your MPI application using BigSim/Charm++.
 

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -109,3 +109,74 @@ Quick start
 BigSim
 ^^^^^^
 
+Installation of BigSim
+""""""""""""""""""""""
+
+Compile BigSim/Charm++ for emulation (see http://charm.cs.illinois.edu/manuals/html/bigsim/manual-1p.html
+for more detail). Use any one of the following commands:
+
+- To use UDP as BigSim/Charm++'s communication layer::
+
+    ./build bgampi net-linux-x86_64 bigemulator --with-production --enable-tracing
+    ./build bgampi net-darwin-x86_64 bigemulator --with-production --enable-tracing
+
+  Or explicitly provide the compiler optimization level::
+
+    ./build bgampi net-linux-x86_64 bigemulator -O2
+
+- To use MPI as BigSim/Charm++'s communication layer::
+
+    ./build bgampi mpi-linux-x86_64 bigemulator --with-production --enable-tracing
+
+Note that this build is used to compile MPI applications so that traces can be
+generated. Hence, the communication layer used by BigSim/Charm++ is not
+important. During simulation, the communication will be replayed using the
+network simulator from CODES. However, the computation time captured here can be
+important if it is not being explicitly replaced at simulation time using
+configuration options. So using appropriate compiler flags is important.
+
+Quick start
+"""""""""""
+
+1. Compile your MPI application using BigSim/Charm++.
+
+ Example commands::
+
+    $CHARM_DIR/bin/ampicc -O2 simplePrg.c -o simplePrg_c
+    $CHARM_DIR/bin/ampiCC -O2 simplePrg.cc -o simplePrg_cxx
+
+2. Emulation to generate traces. When the binary generated is run,
+   BigSim/Charm++ runs the program on the allocated cores as if it were
+   running as usual. Users should provide a few additional arguments to
+   specify the number of MPI processes in the prototype systems.
+
+ If using UDP as the BigSim/Charm++'s communication layer::
+
+    ./charmrun +p<number of real processes> ++nodelist <machine file> ./pgm <program arguments> +vp<number of processes expected on the future system> +x<x dim> +y<y dim> +z<z dim> +bglog
+
+ If using MPI as the BigSim/Charm++'s communication layer::
+
+    mpirun -n<number of real processes> ./pgm <program arguments> +vp<number of processes expected on the future system> +x<x dim> +y<y dim> +z<z dim> +bglog
+
+ Number of real processes is typically equal to the number cores the emulation
+ is being run on.
+
+ *machine file* is the list of systems the emulation should be run on (similar to
+ machine file for MPI; refer to Charm++ website for more details).
+
+ *vp* is the number of MPI ranks that are to be emulated. For simple tests, it can
+ be the same as the number of real processes, in which case one MPI rank is run on
+ each real process (as it happens when a regular program is run). When the
+ number of vp (virtual processes) is higher, BigSim launches user level threads
+ to execute multiple MPI ranks within a process.
+
+ *+x +y +z* defines a 3D grid of the virtual processes. The product of these three
+ dimensions must match the number of vp's. These arguments do not have any
+ effect on the emulation, but exist due to historical reasons.
+
+ *+bglog* instructs bigsim to write the logs to files.
+
+3. When this run is finished, you should see many files named *bgTrace\** in the
+   directory. The total number of such files equals the number of real processes
+   plus one. Their names are bgTrace, bgTrace0, bgTrace1, and so on. 
+   Create a new folder and move all *bgTrace* files to that folder.

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -13,6 +13,7 @@ optimistic mode::
     mpirun -np <p> ../traceR --sync=3  -- <network_config> <tracer_config>
 
 Some useful options to use with TraceR:
+
 --sync                 ROSS's PDES type. 1 - sequential, 2 - conservative, 3 - optimistic
 --nkp                  number of groups used for clustering LPs; recommended value for lower rollbacks: (total #LPs)/(#MPI processes)
 --extramem             number of messages in ROSS's extra message buffer (each message is ~500 bytes, 100K should work for most cases)
@@ -118,6 +119,8 @@ Network specific parameters::
 
 Creating the job placement file
 -------------------------------
+
+See the README in utils for instructions on using the tools to generate the global and job mapping files.
 
 Generating Traces
 -----------------


### PR DESCRIPTION
This PR adds on to the changes in https://github.com/LLNL/TraceR/pull/24, and should be merged after

### Description
Moves most of the UserWriteUp.txt contents to the RTD user guide section on generating traces using Charm++/BigSim , creating the network config file, and tweaks the formatting some more. https://tracer-ryan-test.readthedocs.io/en/docs-update-userwriteup/userguide.html has a build of the docs with these changes.

### Proposed changes
- Add section to RTD user guide on generating traces using Charm++/BigSim
- Add section to RTD user guide on creating the network config file
- Some more small formatting tweaks