### PR TITLE
Add Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,46 @@
 dist: xenial
+language: cpp
+
 addons:
   apt:
     packages:
       - libtool-bin
+      - libmpich-dev
 
 install:
-  - flex --version
-  - bison --version
-  - autoconf --version
-  - automake --version
-  - libtool --version
-  - m4 --version
-  - pkgconfig --version
+  # Install ROSS
+  - |
+    git clone http://github.com/carothersc/ROSS.git ${TRAVIS_BUILD_DIR}/ci-build-deps/ROSS
+    pushd ${TRAVIS_BUILD_DIR}/ci-build-deps/ROSS
+    mkdir build
+    cd build
+    ARCH=x86_64 CC=mpicc CXX=mpicxx cmake -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/ci-deps/ROSS ../
+    make -j3
+    make install
+    popd
+  # Install CODES
+  - |
+    git clone https://xgitlab.cels.anl.gov/codes/codes.git ${TRAVIS_BUILD_DIR}/ci-build-deps/CODES
+    pushd ${TRAVIS_BUILD_DIR}/ci-build-deps/CODES
+    ./prepare.sh
+    mkdir build
+    cd build
+    ../configure --prefix=${TRAVIS_BUILD_DIR}/ci-deps/CODES CC=mpicc CXX=mpicxx PKG_CONFIG_PATH=${TRAVIS_BUILD_DIR}/ci-deps/ROSS/lib/pkgconfig
+    # add --with-dumpi=/path/to/dumpi/install here to enable tracing with dumpi; only needs libundumpi, so can use --disable-libdumpi and --enable-libundumpi when installing DUMPI
+    make -j3
+    make install
+    popd
+  # Install OTF2
+  - |
+    mkdir ${TRAVIS_BUILD_DIR}/ci-build-deps/
+    pushd ${TRAVIS_BUILD_DIR}/ci-build-deps/
+    wget https://www.vi-hps.org/cms/upload/packages/otf2/otf2-2.1.1.tar.gz
+    tar -xf otf2-2.1.1.tar.gz
+    cd otf2-2.1.1
+    mkdir build
+    cd build
+    ../configure --prefix=${TRAVIS_BUILD_DIR}/ci-deps/OTF2 CC=mpicc CXX=mpicxx --enable-shared
+    make -j3
+    make install
+    popd
+    export PATH=$PATH:${TRAVIS_BUILD_DIR}/ci-deps/OTF2/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,6 @@ install:
     
 script:
   - cd tracer
-  - make all PREFIX=${TRAVIS_BUILD_DIR}/install-test CXX=mpicc CXX=mpicxx ROSS_DIR='${TRAVIS_BUILD_DIR}/ci-deps/ROSS' CODES_DIR='${TRAVIS_BUILD_DIR}/ci-deps/CODES' SELECT_TRACE='-DTRACER_OTF_TRACES=1'
+  - make all PREFIX=${TRAVIS_BUILD_DIR}/install-test CXX=mpicc CXX=mpicxx ROSS_DIR="${TRAVIS_BUILD_DIR}/ci-deps/ROSS" CODES_DIR="${TRAVIS_BUILD_DIR}/ci-deps/CODES" SELECT_TRACE="-DTRACER_OTF_TRACES=1"
   - cd ../utils
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,4 @@ install:
     
 script:
   - cd tracer
-  - make --prefix=${TRAVIS_BUILD_DIR}/install-test CXX=mpicc CXX=mpicxx ROSS_DIR='${TRAVIS_BUILD_DIR}/ci-deps/ROSS' CODES_DIR='${TRAVIS_BUILD_DIR}/ci-deps/CODES' SELECT_TRACE='-DTRACER_OTF_TRACES=1'
+  - make all PREFIX=${TRAVIS_BUILD_DIR}/install-test CXX=mpicc CXX=mpicxx ROSS_DIR='${TRAVIS_BUILD_DIR}/ci-deps/ROSS' CODES_DIR='${TRAVIS_BUILD_DIR}/ci-deps/CODES' SELECT_TRACE='-DTRACER_OTF_TRACES=1'

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,3 +48,5 @@ install:
 script:
   - cd tracer
   - make all PREFIX=${TRAVIS_BUILD_DIR}/install-test CXX=mpicc CXX=mpicxx ROSS_DIR='${TRAVIS_BUILD_DIR}/ci-deps/ROSS' CODES_DIR='${TRAVIS_BUILD_DIR}/ci-deps/CODES' SELECT_TRACE='-DTRACER_OTF_TRACES=1'
+  - cd ../utils
+  - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
 install:
   # Install ROSS
   - |
-    git clone http://github.com/carothersc/ROSS.git ${TRAVIS_BUILD_DIR}/ci-build-deps/ROSS
+    git clone https://github.com/ROSS-org/ROSS.git ${TRAVIS_BUILD_DIR}/ci-build-deps/ROSS
     pushd ${TRAVIS_BUILD_DIR}/ci-build-deps/ROSS
     mkdir build
     cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+dist: xenial
+addons:
+  apt:
+    packages:
+
+install:
+  - flex --version
+  - bison --version
+  - autoconf --version
+  - automake --version
+  - libtool --version
+  - m4 --version
+  - pkgconfig --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ dist: xenial
 addons:
   apt:
     packages:
+      - libtool-bin
 
 install:
   - flex --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,3 +44,7 @@ install:
     make install
     popd
     export PATH=$PATH:${TRAVIS_BUILD_DIR}/ci-deps/OTF2/bin
+    
+script:
+  - cd tracer
+  - make --prefix=${TRAVIS_BUILD_DIR}/install-test CXX=mpicc CXX=mpicxx ROSS_DIR='${TRAVIS_BUILD_DIR}/ci-deps/ROSS' CODES_DIR='${TRAVIS_BUILD_DIR}/ci-deps/CODES' SELECT_TRACE='-DTRACER_OTF_TRACES=1'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ TraceR v2.2
 ===========
 
 [![Read the Docs](http://readthedocs.org/projects/tracer-codes/badge/?version=master)](http://tracer-codes.readthedocs.io)
+[![Build Status](https://travis-ci.com/LLNL/TraceR.svg?branch=master)](https://travis-ci.com/LLNL/TraceR)
 
 TraceR is a trace replay tool built upon the ROSS-based CODES simulation
 framework. TraceR can be used for predicting network performance and


### PR DESCRIPTION
### Description
Adds CI builds on Travis of TraceR and utils. This does not build the examples which require Score-P and Charm++ to be built -- in particular, Charm++ takes a significant amount of time to build.

### Proposed changes
- Add .travis.yml config file
- Build TraceR
- Build utils
- Add build status badge to the README